### PR TITLE
Add our own DCAT plugin to override after_show

### DIFF
--- a/ckanext/switzerland/dcat/plugins.py
+++ b/ckanext/switzerland/dcat/plugins.py
@@ -1,0 +1,10 @@
+from ckanext.dcat.plugins import DCATPlugin
+
+
+class OgdchDcatPlugin(DCATPlugin):
+    def after_show(self, context, data_dict):
+        """
+        Override after_show from ckanext_dcat as the set_titles() here
+        destroyed our custom theme
+        """
+        pass

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
         ogdch_group=ckanext.switzerland.plugin:OgdchGroupPlugin
         ogdch_org=ckanext.switzerland.plugin:OgdchOrganizationPlugin
         ogdch_org_search=ckanext.switzerland.plugin:OgdchOrganisationSearchPlugin
+        ogdch_dcat=ckanext.switzerland.dcat.plugins:OgdchDcatPlugin
         dcat_ch_rdf_harvester=ckanext.switzerland.dcat.harvesters:SwissDCATRDFHarvester
 
         [ckan.rdf.profiles]


### PR DESCRIPTION
The original code, that I override is here: https://github.com/ckan/ckanext-dcat/blob/f9e090399b91fd92514ac8c783e3bd65d8cb3942/ckanext/dcat/plugins.py#L99-L113