### PR TITLE
Remove mapping of 'aspx' to 'csv'

### DIFF
--- a/ckanext/switzerland/helpers.py
+++ b/ckanext/switzerland/helpers.py
@@ -314,7 +314,7 @@ def strip_accents(s):
 # all formats that need to be mapped have to be entered lower-case
 def map_to_valid_format(resource_format):
     format_mapping = {
-        'CSV': ['csv', 'aspx', 'text (.csv)', 'comma ...'],
+        'CSV': ['csv', 'text (.csv)', 'comma ...'],
         'GeoJSON': ['geojson'],
         'GeoTIFF': ['geotiff'],
         'GPKG': ['gpkg'],


### PR DESCRIPTION
I could not find any reference of this mapping in any ticket or the
mapping XLS of the client. But it lead to strange mappings where URLs
like http://download.example.com/DownloadFile.aspx?file=pcaxis001 for a
pc axis file where mapped to CSV, because 'aspx' was extracted as the
format from the download URL.