### PR TITLE
use yaml-file for format-mapping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+## Create a pull request
+
+1. Choose the `master` branch as a target for new/changed functionality.
+2. While it's not strictly required, it's highly recommended to create a new branch on your fork for each pull request.
+3. Push to your fork and [submit a pull request][pr].
+4. Check if the [build ran successfully][ci] and try to improve your code if not.
+
+At this point you're waiting for our review.
+We might suggest some changes or improvements or alternatives.
+
+Some things that will increase the chance that your pull request is accepted:
+
+* Write tests.
+* Follow the Python style guide ([PEP-8][pep8]).
+* Write a [good commit message][commit].
+
+[pr]: https://github.com/opendata-swiss/ckanext-switzerland/compare/
+[ci]: https://travis-ci.org/opendata-swiss/ckanext-switzerland
+[pep8]: https://www.python.org/dev/peps/pep-0008/
+[commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/README.md
+++ b/README.md
@@ -76,3 +76,8 @@ do:
     python setup.py develop
     pip install -r dev-requirements.txt
     pip install -r requirements.txt
+
+## Update Format-Mapping
+
+To update the Format-Mapping edit the [mapping.yaml](/ckanext/switzerland/mapping.yaml), following the [YAML-Syntax](http://docs.ansible.com/ansible/latest/YAMLSyntax.html). You can check if your changes are valid by pasting the contents of the required changes into a Syntax-Checker, e.g. [YAML Syntax-Checker](http://www.yamllint.com/).
+Submit a Pull-Request following our [Contribution-Guidelines](CONTRIBUTING.md).

--- a/ckanext/switzerland/helpers.py
+++ b/ckanext/switzerland/helpers.py
@@ -313,34 +313,8 @@ def strip_accents(s):
    return ''.join(c for c in unicodedata.normalize('NFD', s) if unicodedata.category(c) != 'Mn')  # noqa
 
 
-# all formats that need to be mapped have to be entered lower-case
-def map_to_valid_format(resource_format):
-    format_mapping = {
-        'CSV': ['csv', 'text (.csv)', 'comma ...'],
-        'GeoJSON': ['geojson'],
-        'GeoTIFF': ['geotiff'],
-        'GPKG': ['gpkg'],
-        'HTML': ['html'],
-        'INTERLIS': ['interlis'],
-        'JSON': ['json'],
-        'KMZ': ['kmz'],
-        'MULTIFORMAT': ['multiformat'],
-        'ODS': ['ods', 'vnd.oas...', 'vnd.oasis.opendocument.spreadsheet'],
-        'PC-AXIS': ['pc-axis file'],
-        'PDF': ['pdf'],
-        'PNG': ['png'],
-        'RDF': ['sparql-...'],
-        'SHAPEFILE': ['esri shapefile', 'esri geodatabase (....', 'esri file geodatabase', 'esri arcinfo ascii ...'],  # noqa
-        'TXT': ['text', 'txt', 'text (.txt)', 'plain'],
-        'TIFF': ['tiff'],
-        'WCS': ['wcs'],
-        'WFS': ['wfs'],
-        'WMS': ['wms'],
-        'WMTS': ['wmts'],
-        'XLS': ['xls', 'xlsx', 'vnd.openxmlformats-officedocument.spreadsheetml.sheet'],  # noqa
-        'XML': ['xml'],
-        'ZIP': ['zip'],
-    }
+# all formats that need to be mapped have to be entered in the mapping.yaml
+def map_to_valid_format(resource_format, format_mapping):
     resource_format_lower = resource_format.lower()
     for key, values in format_mapping.iteritems():
         if resource_format_lower in values:

--- a/ckanext/switzerland/mapping.yaml
+++ b/ckanext/switzerland/mapping.yaml
@@ -1,0 +1,60 @@
+CSV:
+  - 'csv'
+  - 'text (.csv)'
+  - 'comma ...'
+GeoJSON:
+  - 'geojson'
+GeoTIFF:
+  - 'geotiff'
+GPKG:
+  - 'gpkg'
+HTML:
+  - 'html'
+INTERLIS:
+  - 'interlis'
+JSON:
+  - 'json'
+KMZ:
+  - 'kmz'
+MULTIFORMAT:
+  - 'multiformat'
+ODS:
+  - 'ods'
+  - 'vnd.oas...'
+  - 'vnd.oasis.opendocument.spreadsheet'
+PC-AXIS:
+  - 'pc-axis file'
+PDF:
+  - 'pdf'
+PNG:
+  - 'png'
+RDF:
+  - 'sparql-...'
+SHAPEFILE:
+  - 'esri shapefile'
+  - 'esri geodatabase (....'
+  - 'esri file geodatabase'
+  - 'esri arcinfo ascii ...'
+TXT:
+  - 'text'
+  - 'txt'
+  - 'text (.txt)'
+  - 'plain'
+TIFF:
+  - 'tiff'
+WCS:
+  - 'wcs'
+WFS:
+  - 'wfs'
+WMS:
+  - 'wms'
+WMTS:
+  - 'wmts'
+XLS:
+  - 'xls'
+  - 'xlsx'
+  - 'vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+XML:
+  - 'xml'
+ZIP:
+  - 'zip'

--- a/ckanext/switzerland/plugin.py
+++ b/ckanext/switzerland/plugin.py
@@ -142,6 +142,10 @@ class OgdchPlugin(plugins.SingletonPlugin):
         }
 
 
+class FormatMappingNotLoadedError(Exception):
+    pass
+
+
 class OgdchLanguagePlugin(plugins.SingletonPlugin):
     """
     Handles language dictionaries in data_dict (pkg_dict).
@@ -152,11 +156,15 @@ class OgdchLanguagePlugin(plugins.SingletonPlugin):
 
     def update_config(self, config):
         try:
-            with open(os.path.join(__location__, 'mapping.yaml'),
-                      'r') as format_mapping_file:
+            mapping_path = os.path.join(__location__, 'mapping.yaml')
+            with open(mapping_path, 'r') as format_mapping_file:
                 self.format_mapping = yaml.safe_load(format_mapping_file)
-        except IOError:
-            self.format_mapping = {}
+        except (IOError, yaml.YAMLError) as exception:
+            raise FormatMappingNotLoadedError(
+                'Loading Format-Mapping from Path: (%s) '
+                'failed with Exception: (%s)'
+                % (mapping_path, exception)
+            )
 
     def get_format_mapping(self):
         return self.format_mapping

--- a/ckanext/switzerland/tests/test_mapping.yaml
+++ b/ckanext/switzerland/tests/test_mapping.yaml
@@ -1,0 +1,60 @@
+CSV:
+  - 'csv'
+  - 'text (.csv)'
+  - 'comma ...'
+GeoJSON:
+  - 'geojson'
+GeoTIFF:
+  - 'geotiff'
+GPKG:
+  - 'gpkg'
+HTML:
+  - 'html'
+INTERLIS:
+  - 'interlis'
+JSON:
+  - 'json'
+KMZ:
+  - 'kmz'
+MULTIFORMAT:
+  - 'multiformat'
+ODS:
+  - 'ods'
+  - 'vnd.oas...'
+  - 'vnd.oasis.opendocument.spreadsheet'
+PC-AXIS:
+  - 'pc-axis file'
+PDF:
+  - 'pdf'
+PNG:
+  - 'png'
+RDF:
+  - 'sparql-...'
+SHAPEFILE:
+  - 'esri shapefile'
+  - 'esri geodatabase (....'
+  - 'esri file geodatabase'
+  - 'esri arcinfo ascii ...'
+TXT:
+  - 'text'
+  - 'txt'
+  - 'text (.txt)'
+  - 'plain'
+TIFF:
+  - 'tiff'
+WCS:
+  - 'wcs'
+WFS:
+  - 'wfs'
+WMS:
+  - 'wms'
+WMTS:
+  - 'wmts'
+XLS:
+  - 'xls'
+  - 'xlsx'
+  - 'vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+XML:
+  - 'xml'
+ZIP:
+  - 'zip'

--- a/ckanext/switzerland/tests/test_plugin.py
+++ b/ckanext/switzerland/tests/test_plugin.py
@@ -3,6 +3,13 @@ import ckanext.switzerland.plugin as plugin
 from nose.tools import *  # noqa
 import mock
 import sys
+import os
+import yaml
+
+__location__ = os.path.realpath(os.path.join(
+    os.getcwd(),
+    os.path.dirname(__file__))
+)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -16,8 +23,18 @@ class TestPlugin(unittest.TestCase):
     def tearDown(self):
         return
 
+    def _load_test_format_mapping(self):
+        try:
+            with open(os.path.join(__location__, 'test_mapping.yaml'),
+                      'r') as format_mapping_file:
+                return yaml.safe_load(format_mapping_file)
+        except IOError:
+            raise IOError
+
     def test_prepare_resource_format(self):
         ogdch_language_plugin = plugin.OgdchLanguagePlugin()
+
+        ogdch_language_plugin.format_mapping = self._load_test_format_mapping()
 
         resource_with_no_format_and_no_download_url = {
             'download_url': None,

--- a/ckanext/switzerland/tests/test_plugin.py
+++ b/ckanext/switzerland/tests/test_plugin.py
@@ -24,12 +24,9 @@ class TestPlugin(unittest.TestCase):
         return
 
     def _load_test_format_mapping(self):
-        try:
-            with open(os.path.join(__location__, 'test_mapping.yaml'),
-                      'r') as format_mapping_file:
-                return yaml.safe_load(format_mapping_file)
-        except IOError:
-            raise IOError
+        with open(os.path.join(__location__, 'test_mapping.yaml'),
+                  'r') as format_mapping_file:
+            return yaml.safe_load(format_mapping_file)
 
     def test_prepare_resource_format(self):
         ogdch_language_plugin = plugin.OgdchLanguagePlugin()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests[security]==2.7.0
 urllib3[secure]==1.19.1
 iribaker==0.1.2
+pyyaml==3.11


### PR DESCRIPTION
To make it easier to maintain the mapping, we use a yaml-file that contains the format-mapping.