### PR TITLE
override default i18n_domain

### DIFF
--- a/ckanext/switzerland/plugin.py
+++ b/ckanext/switzerland/plugin.py
@@ -45,6 +45,12 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IFacets)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.ITemplateHelpers)
+    plugins.implements(plugins.ITranslation)
+
+    # ITranslation
+
+    def i18n_domain(self):
+        return 'ckanext-switzerland'
 
     # IConfigurer
 


### PR DESCRIPTION
The default if not overriden would be ckanext-ogdch, but we are using ckanext-switzerland