### PR TITLE
refactor group- and hierarchy-controller for ckan 2.8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 env:
     - CKANVERSION=master
-    - CKANVERSION=2.6
+    - CKANVERSION=2.8
 
 services:
     - redis-server

--- a/ckanext/switzerland/controller.py
+++ b/ckanext/switzerland/controller.py
@@ -4,13 +4,13 @@ import logging
 from ckan.plugins import toolkit as tk
 import ckan.model as model
 import ckan.logic as logic
-import ckan.lib.maintain as maintain
 import ckan.lib.plugins
-from ckan.common import c, _, g, request, OrderedDict
+from ckan.common import c, config, _, request, OrderedDict
 import ckan.lib.helpers as h
 import ckan.authz as authz
 import ckan.lib.search as search
 import ckan.lib.base as base
+from six import string_types
 
 from ckanext.hierarchy.controller import _children_name_list
 import ckan.controllers.organization as organization
@@ -127,7 +127,7 @@ class OgdchOrganizationSearchController(organization.OrganizationController):
                 'license_id': _('Licenses')
             }
 
-            for facet in g.facets:
+            for facet in h.facets():
                 if facet in default_facet_titles:
                     facets[facet] = default_facet_titles[facet]
                 else:
@@ -184,15 +184,14 @@ class OgdchOrganizationSearchController(organization.OrganizationController):
             )
 
             c.group_dict['package_count'] = query['count']
-            c.facets = query['facets']
-            maintain.deprecate_context_item('facets',
-                                            'Use `c.search_facets` instead.')
 
             c.search_facets = query['search_facets']
             c.search_facets_limits = {}
-            for facet in c.facets.keys():
+            for facet in c.search_facets.keys():
                 limit = int(request.params.get('_%s_limit' % facet,
-                            g.facets_default_number))
+                                               config.get(
+                                                   'search.facets.default',
+                                                   10)))
                 c.search_facets_limits[facet] = limit
             c.page.items = query['results']
 
@@ -201,7 +200,7 @@ class OgdchOrganizationSearchController(organization.OrganizationController):
         except search.SearchError, se:
             log.error('Group search error: %r', se.args)
             c.query_error = True
-            c.facets = {}
+            c.search_facets = {}
             c.page = h.Page(collection=[])
 
         self._setup_template_variables(
@@ -232,12 +231,11 @@ class OgdchGroupSearchController(group.GroupController):
                    'for_view': True, 'extras_as_string': True}
 
         q = c.q = request.params.get('q', '')
-        fq = ''
         # Search within group
         if c.group_dict.get('is_organization'):
-            fq += ' owner_org:"%s"' % c.group_dict.get('id')
+            fq = 'owner_org:"%s"' % c.group_dict.get('id')
         else:
-            fq += ' groups:"%s"' % c.group_dict.get('name')
+            fq = 'groups:"%s"' % c.group_dict.get('name')
 
         c.description_formatted = \
             h.render_markdown(c.group_dict.get('description'))
@@ -259,7 +257,7 @@ class OgdchGroupSearchController(group.GroupController):
             controller = lookup_group_controller(group_type)
             action = 'bulk_process' if c.action == 'bulk_process' else 'read'
             url = h.url_for(controller=controller, action=action, id=id)
-            params = [(k, v.encode('utf-8') if isinstance(v, basestring)
+            params = [(k, v.encode('utf-8') if isinstance(v, string_types)
                        else str(v)) for k, v in params]
             return url + u'?' + urlencode(params)
 
@@ -272,8 +270,9 @@ class OgdchGroupSearchController(group.GroupController):
         c.drill_down_url = drill_down_url
 
         def remove_field(key, value=None, replace=None):
+            controller = lookup_group_controller(group_type)
             return h.remove_url_param(key, value=value, replace=replace,
-                                      controller='group', action='read',
+                                      controller=controller, action='read',
                                       extras=dict(id=c.group_dict.get('name')))
 
         c.remove_field = remove_field
@@ -285,6 +284,7 @@ class OgdchGroupSearchController(group.GroupController):
 
         try:
             c.fields = []
+            c.fields_grouped = {}
             search_extras = {}
             for (param, value) in request.params.items():
                 if param not in ['q', 'page', 'sort'] \
@@ -292,16 +292,12 @@ class OgdchGroupSearchController(group.GroupController):
                     if not param.startswith('ext_'):
                         c.fields.append((param, value))
                         fq += ' %s: "%s"' % (param, value)
+                        if param not in c.fields_grouped:
+                            c.fields_grouped[param] = [value]
+                        else:
+                            c.fields_grouped[param].append(value)
                     else:
                         search_extras[param] = value
-
-            user_member_of_orgs = [org['id'] for org
-                                   in h.organizations_available('read')]
-
-            if (c.group and c.group.id in user_member_of_orgs):
-                context['ignore_capacity_check'] = True
-            else:
-                fq += ' capacity:"public"'
 
             facets = OrderedDict()
 
@@ -311,7 +307,7 @@ class OgdchGroupSearchController(group.GroupController):
                                     'res_format': _('Formats'),
                                     'license_id': _('Licenses')}
 
-            for facet in g.facets:
+            for facet in h.facets():
                 if facet in default_facet_titles:
                     facets[facet] = default_facet_titles[facet]
                 else:
@@ -320,15 +316,12 @@ class OgdchGroupSearchController(group.GroupController):
             # Facet titles
             self._update_facet_titles(facets, group_type)
 
-            if 'capacity' in facets and (group_type != 'organization' or
-                                         not user_member_of_orgs):
-                del facets['capacity']
-
             c.facet_titles = facets
 
             data_dict = {
                 'q': q,
                 'fq': fq,
+                'include_private': True,
                 'facet.field': facets.keys(),
                 'rows': limit,
                 'sort': sort_by,
@@ -349,24 +342,23 @@ class OgdchGroupSearchController(group.GroupController):
             )
 
             c.group_dict['package_count'] = query['count']
-            c.facets = query['facets']
-            maintain.deprecate_context_item('facets',
-                                            'Use `c.search_facets` instead.')
 
             c.search_facets = query['search_facets']
             c.search_facets_limits = {}
-            for facet in c.facets.keys():
+            for facet in c.search_facets.keys():
                 limit = int(request.params.get('_%s_limit' % facet,
-                                               g.facets_default_number))
+                                               config.get(
+                                                   'search.facets.default',
+                                                   10)))
                 c.search_facets_limits[facet] = limit
             c.page.items = query['results']
 
             c.sort_by_selected = sort_by
 
-        except search.SearchError, se:
+        except search.SearchError as se:
             log.error('Group search error: %r', se.args)
             c.query_error = True
-            c.facets = {}
+            c.search_facets = {}
             c.page = h.Page(collection=[])
 
         self._setup_template_variables(

--- a/ckanext/switzerland/controller.py
+++ b/ckanext/switzerland/controller.py
@@ -384,8 +384,6 @@ class OgdchPermaController(base.BaseController):
                 {'identifier': id}
             )
             # redirect to dataset detail page
-            tk.redirect_to(controller='package',
-                           action='read',
-                           id=dataset['name'])
+            tk.redirect_to('dataset_read', id=dataset['name'])
         except NotFound:
             abort(404, _('Dataset not found'))

--- a/ckanext/switzerland/plugin.py
+++ b/ckanext/switzerland/plugin.py
@@ -603,9 +603,9 @@ class OgdchPackagePlugin(OgdchLanguagePlugin):
         # therefore no results are returned. If the terms are transliterated to
         # ascii everything works since the documents are anyway index as ascii
         # using an ASCIIFoldingFilterFactory.
-        # As long as we don't mess up any special solr markup or fields with 
+        # As long as we don't mess up any special solr markup or fields with
         # UTF-8 characters, this should be save.
-        # TODO: Remove once solr and/or CKAN is upgraded, check if search for 
+        # TODO: Remove once solr and/or CKAN is upgraded, check if search for
         # terms with umlauts works again
         q = search_params.get('q')
         if q:

--- a/ckanext/switzerland/templates/base.html
+++ b/ckanext/switzerland/templates/base.html
@@ -13,7 +13,7 @@
 {%- endblock -%}
 
 {%- block title -%}
-  {% block subtitle %}{{ _('Home') }}{% endblock %} | {{ app_globals.site_title }}
+  {% block subtitle %}{{ _('Home') }}{% endblock %} | {{ g.site_title }}
 {%- endblock -%}
 
 {% block styles %}

--- a/ckanext/switzerland/templates/error_document_template.html
+++ b/ckanext/switzerland/templates/error_document_template.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% block subtitle %}{{ gettext('Error %(error_code)s', error_code=c.code[0]) }}{% endblock %}
+{% block subtitle %}{{ gettext('Error %(error_code)s', error_code=code[0]) }}{% endblock %}
 
 {% block breadcrumb_content %}
 <li class="active">{{ _('Page not found') }}</li>

--- a/ckanext/switzerland/templates/footer.html
+++ b/ckanext/switzerland/templates/footer.html
@@ -17,7 +17,7 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-3 col-xs-6">
-        <a href="{{ h.url_for(controller='package', action='search') }}">
+        <a href="{{ h.url_for('search') }}">
           {% set dataset_count = h.get_dataset_count() %}
           <div class="statsnumber">
             {{ dataset_count }} <i class="fa fa-files-o"></i>
@@ -81,7 +81,7 @@
         <li><a href="{{ h.url('/about') }}">{{ _('About') }}</a></li>
         <li><a href="{{ h.url('/faq') }}">{{ _('FAQ') }}</a></li>
         <li><a href="{{ h.url('/contact') }}">{{ _('Contact') }}</a></li>
-        <li><a href="{{ h.url_for(controller='package', action='search') }}">{{ _('Data') }}</a></li>
+        <li><a href="{{ h.url_for('search') }}">{{ _('Data') }}</a></li>
         <li><a href="{{ h.url_for(controller='organization', action='index') }}">{{ _('Organizations') }}</a></li>
         <li><a href="{{ h.url('/app') }}">{{ _('Applications') }}</a></li>
         <li><a href="{{ h.url('/terms-of-use') }}">{{ _('Terms of use') }}</a></li>

--- a/ckanext/switzerland/templates/header.html
+++ b/ckanext/switzerland/templates/header.html
@@ -54,7 +54,7 @@
             </ul>
           </li>
           <li class="search">
-            <a href="{{ h.url_for(controller='package', action='search') }}" title="{{ _('Search') }}"><i class="fa fa-search" aria-hidden="true"></i></a>
+            <a href="{{ h.url_for('dataset.search') }}" title="{{ _('Search') }}"><i class="fa fa-search" aria-hidden="true"></i></a>
           </li>
         </ul>
       </div>

--- a/ckanext/switzerland/templates/header.html
+++ b/ckanext/switzerland/templates/header.html
@@ -21,7 +21,7 @@
         <span class="icon-bar"></span>
       </button>
       <a class="navbar-brand" href="{{ h.url('home') }}">
-        <img src="/content/themes/wp-ogdch-theme/assets/images/logo_horizontal.svg" onerror="this.onerror=null;this.src='/content/themes/wp-ogdch-theme/assets/images/logo_horizontal.png'" class="navbar-brand-image" alt="{{ app_globals.site_title }}" title="{{ app_globals.site_title }}" />
+        <img src="/content/themes/wp-ogdch-theme/assets/images/logo_horizontal.svg" onerror="this.onerror=null;this.src='/content/themes/wp-ogdch-theme/assets/images/logo_horizontal.png'" class="navbar-brand-image" alt="{{ g.site_title }}" title="{{ g.site_title }}" />
       </a>
     </div>
 

--- a/ckanext/switzerland/templates/organization/index.html
+++ b/ckanext/switzerland/templates/organization/index.html
@@ -1,5 +1,11 @@
 {% extends "page.html" %}
 
+
+{% if c.page %}
+{% set page = c.page %}
+{% set q = c.q %}
+{% endif %}
+
 {% set page_description = _('Authorities from the Confederation, cantons and communes as well as third parties that perform tasks on behalf of the state can publish their open data on the opendata.swiss portal. Is your organization missing from the list? Get involved.') %}
 {% set placeholder = placeholder if placeholder else _('Search organizations...') %}
 
@@ -35,7 +41,7 @@
       <div class="row">
         <div class="col-xs-12">
           <div class="form-group has-feedback">
-            <input type="search" class="form-control input-lg" id="organization-search" name="q" value="{{c.q}}" results="0" autocomplete="off" placeholder="{{ placeholder }}">
+            <input type="search" class="form-control input-lg" id="organization-search" name="q" value="{{q}}" results="0" autocomplete="off" placeholder="{{ placeholder }}">
             <i class="fa fa-search form-control-feedback" aria-hidden="true"></i>
           </div>
         </div>
@@ -43,16 +49,16 @@
 
       <div class="row">
         <div class="col-xs-12">
-          <h2><span class="result-count">{{ c.page.item_count }}</span> <span class="result-count-footer">{{ ungettext('organization', 'organizations', c.page.item_count).format(num=c.page.item_count) }}</span></h2>
+          <h2><span class="result-count">{{ page.item_count }}</span> <span class="result-count-footer">{{ ungettext('organization', 'organizations', page.item_count).format(num=page.item_count) }}</span></h2>
         </div>
       </div>
 
       <div class="row">
         <div class="col-xs-12">
           {% block organizations_list %}
-            {% if c.page.items or request.params %}
-              {% if c.page.items %}
-                {% snippet "organization/snippets/organization_list.html", organizations=c.page.items %}
+            {% if page.items or request.params %}
+              {% if page.items %}
+                {% snippet "organization/snippets/organization_list.html", organizations=page.items %}
               {% endif %}
             {% else %}
               <p class="empty">

--- a/ckanext/switzerland/templates/package/base.html
+++ b/ckanext/switzerland/templates/package/base.html
@@ -13,11 +13,11 @@
       <li>{% link_for _('Organizations'), controller='organization', action='index' %}</li>
       <li>{% link_for organization.title|truncate(30), controller='organization', action='read', id=organization.name %}</li>
     {% else %}
-      <li>{% link_for _('Data'), controller='package', action='search' %}</li>
+      <li>{% link_for _('Data'), 'search' %}</li>
     {% endif %}
     {% set pkg_title = pkg.title or pkg.name %}
-    <li{{ self.breadcrumb_content_selected() }}>{% link_for pkg_title|truncate(30), controller='package', action='read', id=pkg.name %}</li>
+    <li{{ self.breadcrumb_content_selected() }}>{% link_for pkg_title|truncate(30), 'dataset_read', id=pkg.name %}</li>
   {% else %}
-    <li>{% link_for _('Data'), controller='package', action='search' %}</li>
+    <li>{% link_for _('Data'), 'search' %}</li>
   {% endif %}
 {% endblock %}

--- a/ckanext/switzerland/templates/package/read_base.html
+++ b/ckanext/switzerland/templates/package/read_base.html
@@ -8,7 +8,7 @@
 
 {% block links -%}
   {{ super() }}
-  <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(controller='package', action='read', id=pkg.id, format='rdf', qualified=True) }}"/>
+  <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for('dataset_read', id=pkg.id, format='rdf', qualified=True) }}"/>
 {% endblock -%}
 
 {% block content_primary_nav %}

--- a/ckanext/switzerland/templates/package/search.html
+++ b/ckanext/switzerland/templates/package/search.html
@@ -4,7 +4,7 @@
 {% block subtitle %}{{ _('Data') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('Data'), controller='package', action='search' %}</li>
+  <li class="active">{% link_for _('Data'), 'search' %}</li>
 {% endblock %}
 
 {% block page_title %}

--- a/ckanext/switzerland/templates/package/snippets/keywords.html
+++ b/ckanext/switzerland/templates/package/snippets/keywords.html
@@ -7,13 +7,13 @@
             {%- set current_lang = h.lang() -%}
             {% set keyword_truncated = h.truncate(keyword, 22) %}
             {% if current_lang == 'de' %}
-               <li><a class="label label-primary-gray" href="{% url_for controller='package', action='search', keywords_de=keyword %}" title="{{ keyword if keyword != keyword_truncated else '' }}">{{ keyword_truncated }}</a></li>
+               <li><a class="label label-primary-gray" href="{% url_for 'search', keywords_de=keyword %}" title="{{ keyword if keyword != keyword_truncated else '' }}">{{ keyword_truncated }}</a></li>
             {% elif current_lang == 'fr' %}
-               <li><a class="label label-primary-gray" href="{% url_for controller='package', action='search', keywords_fr=keyword %}" title="{{ keyword if keyword != keyword_truncated else '' }}">{{ keyword_truncated }}</a></li>
+               <li><a class="label label-primary-gray" href="{% url_for 'search', keywords_fr=keyword %}" title="{{ keyword if keyword != keyword_truncated else '' }}">{{ keyword_truncated }}</a></li>
             {% elif current_lang == 'it' %}
-               <li><a class="label label-primary-gray" href="{% url_for controller='package', action='search', keywords_it=keyword %}" title="{{ keyword if keyword != keyword_truncated else '' }}">{{ keyword_truncated }}</a></li>
+               <li><a class="label label-primary-gray" href="{% url_for 'search', keywords_it=keyword %}" title="{{ keyword if keyword != keyword_truncated else '' }}">{{ keyword_truncated }}</a></li>
             {% else %}
-               <li><a class="label label-primary-gray" href="{% url_for controller='package', action='search', keywords_en=keyword %}" title="{{ keyword if keyword != keyword_truncated else '' }}">{{ keyword_truncated }}</a></li>
+               <li><a class="label label-primary-gray" href="{% url_for 'search', keywords_en=keyword %}" title="{{ keyword if keyword != keyword_truncated else '' }}">{{ keyword_truncated }}</a></li>
             {% endif %}
           {% endfor %}
         </ul>

--- a/ckanext/switzerland/templates/package/snippets/related_datasets.html
+++ b/ckanext/switzerland/templates/package/snippets/related_datasets.html
@@ -23,7 +23,7 @@ Example:
           {% if see_also and see_also.dataset_identifier %}
             {% set related_dataset = h.get_dataset_by_identifier(see_also.dataset_identifier) %}
             {% if related_dataset %}
-              <li>{{ h.link_to(related_dataset.title, h.url_for(controller='package', action='read', id=related_dataset.name)) }}</li>
+              <li>{{ h.link_to(related_dataset.title, h.url_for('dataset_read', id=related_dataset.name)) }}</li>
             {% else %}
               <li>{{ see_also.dataset_identifier }}</li>
             {% endif %}

--- a/ckanext/switzerland/templates/package/snippets/resource_item.html
+++ b/ckanext/switzerland/templates/package/snippets/resource_item.html
@@ -1,6 +1,6 @@
 {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
-{% set url_action = 'resource_edit' if url_is_edit and can_edit else 'resource_read' %}
-{% set url = h.url_for(controller='package', action=url_action, id=pkg.name, resource_id=res.id) %}
+{% set url_action = 'resource.edit' if url_is_edit and can_edit else 'resource.read' %}
+{% set url = h.url_for(url_action, id=pkg.name, resource_id=res.id) %}
 {% set res_title = res.title or pkg.title or pkg.name %}
 
 <li class="resource-item" data-id="{{ res.id }}">

--- a/ckanext/switzerland/templates/snippets/package_item.html
+++ b/ckanext/switzerland/templates/snippets/package_item.html
@@ -33,7 +33,7 @@ Example:
               {% endif %}
             {% endblock %}
             {% block heading_title %}
-              {{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='package', action='read', id=package.name)) }}
+              {{ h.link_to(h.truncate(title, truncate_title), h.url_for('dataset_read', id=package.name)) }}
             {% endblock %}
             {% block heading_meta %}
               {% if package.get('state', '').startswith('draft') %}

--- a/ckanext/switzerland/tests/test_controller.py
+++ b/ckanext/switzerland/tests/test_controller.py
@@ -101,7 +101,7 @@ class TestController(helpers.FunctionalTestBase):
 
         # no locale, should default to EN
         url = url_for('organizations_index')
-        assert_equal(url, '/organization')
+        assert url.startswith('/organization'), "URL does not start with /organization"
 
         response = app.get(url, status=200)
 

--- a/ckanext/switzerland/tests/test_controller.py
+++ b/ckanext/switzerland/tests/test_controller.py
@@ -101,23 +101,20 @@ class TestController(helpers.FunctionalTestBase):
 
         # no locale, should default to EN
         url = url_for('organizations_index')
-        assert url.startswith('/organization'), "URL does not start with /organization"
+        assert url.startswith('/organization'), "URL %s does not start with /organization" % url
 
         response = app.get(url, status=200)
 
         assert '/en/organization/test-org' in response
 
         # set locale via CKAN_LANG to IT
-        url = url_for('organizations_index')
-        assert_equal(url, '/organization')
-
         response = app.get(url, status=200, extra_environ={'CKAN_LANG': 'it', 'CKAN_CURRENT_URL': url})
 
         assert '/it/organization/test-org' in response
 
         # locale DE
         url = url_for('organizations_index', locale='de')
-        assert_equal(url, '/de/organization')
+        assert url.startswith('/de/organization'), "URL %s does not start with /de/organization" % url
 
         response = app.get(url, status=200)
 
@@ -125,7 +122,7 @@ class TestController(helpers.FunctionalTestBase):
 
         # locale FR
         url = url_for('organizations_index', locale='fr')
-        assert_equal(url, '/fr/organization')
+        assert url.startswith('/fr/organization'), "URL %s does not start with /fr/organization" % url
 
         response = app.get(url, status=200)
 


### PR DESCRIPTION
Removed and replaced functionality because of deprecation (c.facets) or because of flask (g-context)