### PR TITLE
Remove colon followed by a space

### DIFF
--- a/ckanext/switzerland/plugin.py
+++ b/ckanext/switzerland/plugin.py
@@ -617,6 +617,10 @@ class OgdchPackagePlugin(OgdchLanguagePlugin):
         if 'dataset_type:' not in fq:
             search_params.update({'fq': "%s +dataset_type:dataset" % fq})
 
+        # remove colon followed by a space from q to avoid false negatives
+        q = search_params.get('q', '')
+        search_params['q'] = re.sub(":\s", " ", q)
+
         return search_params
 
     # IDataPusher


### PR DESCRIPTION
Otherwise queries like "Test: this is a dataset" will not use the dismax
query parser of Solr, instead solr tries to find documents with the
value "this is a dataset" in the field "Test".

By removing the colon, we can avoid this