### PR TITLE
Add command to delete old harvester jobs and objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ paster --plugin=ckanext-switzerland ogdch cleanup_datastore -c /var/www/ckan/dev
 This commands deletes the harvest jobs and objects per source and overall leaving only the latest n,
 where n and the source are optional arguments. The command is supposed to be used in a cron job to 
 provide for a regular cleanup of harvest jobs, so that the database is not overloaded with unneeded data
-of past job runs.
+of past job runs. It has a dryrun option so that it can be tested what will get be deleted in the 
+database before the actual database changes are performed.
 
 ```bash
-paster --plugin=ckanext-switzerland ogdch cleanup_harvestjobs [{source_id}] [--keep={n}}] -c /var/www/ckan/development.ini
+paster --plugin=ckanext-switzerland ogdch cleanup_harvestjobs [{source_id}] [--keep={n}}] [--dryrun] -c /var/www/ckan/development.ini
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ This extension uses the following config options (.ini file)
     # the URL of the WordPress AJAX interface
     ckanext.switzerland.wp_ajax_url = https://opendata.swiss/cms/wp-admin/admin-ajax.php
 
+    # number of harvest jobs to keep per harvest source when cleaning up harvest objects   
+    ckanext.switzerland.number_harvest_jobs_per_source = 2
+
     # piwik config
     piwik.site_id = 1
     piwik.url = piwik.opendata.swiss

--- a/README.md
+++ b/README.md
@@ -24,13 +24,24 @@ All translations are done via Transifex. To compile the po files use the followi
 
 ## Command
 
-This extension currently provides one paster command, to cleanup the datastore database.
+This extension currently provides two paster commands: 
+### Command to cleanup the datastore database.
 [Datastore currently does not delete tables](https://github.com/ckan/ckan/issues/3422) when the corresponding resource is deleted.
 This command finds these orphaned tables and deletes its rows to free the space in the database.
 It is meant to be run regularly by a cronjob.
 
 ```bash
 paster --plugin=ckanext-switzerland ogdch cleanup_datastore -c /var/www/ckan/development.ini
+```
+
+### Command to cleanup the harvest jobs.
+This commands deletes the harvest jobs and objects per source and overall leaving only the latest n,
+where n and the source are optional arguments. The command is supposed to be used in a cron job to 
+provide for a regular cleanup of harvest jobs, so that the database is not overloaded with unneeded data
+of past job runs.
+
+```bash
+paster --plugin=ckanext-switzerland ogdch cleanup_harvestjobs [{source_id}] [--keep={n}}] -c /var/www/ckan/development.ini
 ```
 
 ## Installation

--- a/ckanext/switzerland/commands.py
+++ b/ckanext/switzerland/commands.py
@@ -18,7 +18,7 @@ class OgdchCommand(ckan.lib.cli.CkanCommand):
         # Cleanup harvester jobs and objects:
         # - deletes all the harvest jobs and objects except the latest n
         # - the default number of jobs to keep is 10
-        paster ogdch cleanup_harvestjobs [{source_id}] [--keep={n}}]
+        paster ogdch cleanup_harvestjobs [{source_id}] [--keep={n}}] [--dryrun}]
     '''
     summary = __doc__.split('\n')[0]
     usage = __doc__
@@ -29,6 +29,10 @@ class OgdchCommand(ckan.lib.cli.CkanCommand):
             '--keep', action="store", type="int", dest='nr_of_jobs_to_keep',
             default=10,
             help='The number of latest harvest jobs to keep')
+        self.parser.add_option(
+            '--dryrun', action="store_true", dest='dryrun',
+            default=False,
+            help='dryrun of cleanup harvestjobs')
 
     def command(self):
         # load pylons config
@@ -147,8 +151,9 @@ class OgdchCommand(ckan.lib.cli.CkanCommand):
         else:
             print('cleaning up jobs for all harvest sources')
 
-        # get named argument
+        # get named arguments
         data_dict['number_of_jobs_to_keep'] = self.options.nr_of_jobs_to_keep
+        data_dict['dryrun'] = self.options.dryrun
 
         # set context
         context = {'model': model,

--- a/ckanext/switzerland/logic.py
+++ b/ckanext/switzerland/logic.py
@@ -8,8 +8,6 @@ from ckan.logic import ActionError, NotFound, ValidationError
 import ckan.plugins.toolkit as tk
 from ckan.lib.search.common import make_connection
 from ckanext.switzerland.helpers import get_content_headers
-from collections import defaultdict
-import ckan.model as model
 from ckanext.harvest.model import HarvestSource, HarvestJob, HarvestObject
 
 import logging
@@ -163,7 +161,7 @@ def ogdch_autosuggest(context, data_dict):
     raise ActionError('Error retrieving suggestions from solr')
 
 
-def ogdch_clean_harvester_jobs(context, data_dict):
+def ogdch_cleanup_harvestjobs(context, data_dict):
     """
     cleans up the database for harvest objects and related tables for all
     harvesting jobs except the latest
@@ -177,51 +175,63 @@ def ogdch_clean_harvester_jobs(context, data_dict):
     tk.check_access('harvest_sources_clear', context, data_dict)
     model = context['model']
 
-    # get sources to clear from data_dict
+    # get sources from data_dict
     if 'harvest_source_id' in data_dict:
         harvest_source_id = data_dict['harvest_source_id']
         source = HarvestSource.get(harvest_source_id)
         if not source:
-            log.error('Harvest source %s does not exist', harvest_source_id)
-            raise NotFound('Harvest source %s does not exist' % harvest_source_id)
-        sources_to_clear = [source.id]
+            log.error('Harvest source {} does not exist'.format(
+                harvest_source_id))
+            raise NotFound('Harvest source {} does not exist'.format(
+                harvest_source_id))
+        sources_to_cleanup = [source.id]
     else:
         all_sources = model.Session.query(HarvestSource.id).all()
-        sources_to_clear = list(itertools.chain(*all_sources))
+        sources_to_cleanup = list(itertools.chain(*all_sources))
 
-    log.info('Harvest sources clearing called for: {}'.format(','.join(sources_to_clear)))
+    log.info('Harvest job cleanup called for sources: {}'.format(
+        ','.join(sources_to_cleanup)))
 
     # get number of jobs to keep form data_dict
     if 'number_of_jobs_to_keep' in data_dict:
         number_of_jobs_to_keep = data_dict['number_of_jobs_to_keep']
     else:
-        log.error('Configuration missing for number of jobs to keep when clearing harvest sources')
-        raise ValidationError('Configuration missing for number of jobs to keep when clearing harvest sources')
+        log.error(
+            'Configuration missing for number of harvest jobs to keep')
+        raise ValidationError(
+            'Configuration missing for number of harvest jobs to keep')
 
-    log.info('Number of most recent jobs per source to keep: {}'.format(number_of_jobs_to_keep))
+    log.info('Number of most recent jobs per source to keep: {}'.format(
+        number_of_jobs_to_keep))
 
     # init list of jobs and objects to delete
     delete_jobs_ids_all = []
     delete_objects_ids_all = []
 
-    for source in sources_to_clear:
+    for source in sources_to_cleanup:
         # get jobs ordered by their creations date
         delete_jobs = model.Session.query(HarvestJob) \
             .filter(HarvestJob.source_id == source) \
             .order_by(HarvestJob.created.desc()).all()
 
         # decide which jobs to keep or delete on their order
-        delete_jobs_ids = [job.id for job in delete_jobs][number_of_jobs_to_keep:]
-        keep_jobs_ids = [job.id for job in delete_jobs][:number_of_jobs_to_keep]
+        delete_jobs_ids = \
+            [job.id for job in delete_jobs][number_of_jobs_to_keep:]
+        keep_jobs_ids = \
+            [job.id for job in delete_jobs][:number_of_jobs_to_keep]
 
         # log all job for a source with the decision to delete or keep them
-        log.info('Clear harvest source {}'.format(source))
-        log.debug('- jobs_to_keep: {}'.format(','.join(keep_jobs_ids)))
+        log.info('Cleanup harvest jobs for source {}'.format(source))
+        log.debug('- jobs_to_keep: {}'.format(
+            ','.join(keep_jobs_ids)))
         for job in delete_jobs[:number_of_jobs_to_keep]:
-            log.debug('    - job {}: created:{}, status:{}'.format(job.id, job.created, job.status))
-        log.debug('- jobs to delete: {}'.format(','.join(delete_jobs_ids)))
+            log.debug('    - job {}: created:{}, status:{}'.format(
+                job.id, job.created, job.status))
+        log.debug('- jobs to delete: {}'.format(
+            ','.join(delete_jobs_ids)))
         for job in delete_jobs[number_of_jobs_to_keep:]:
-            log.debug('    - job {}: created:{}, status:{}'.format(job.id, job.created, job.status))
+            log.debug('    - job {}: created:{}, status:{}'.format(
+                job.id, job.created, job.status))
 
         # add to list of jobs to delete
         delete_jobs_ids_all.extend(delete_jobs_ids)
@@ -242,20 +252,26 @@ def ogdch_clean_harvester_jobs(context, data_dict):
 
         # perform delete
         sql = '''begin;
-        delete from harvest_object_error where harvest_object_id in ('{delete_objects_values}');
-        delete from harvest_object_extra where harvest_object_id in ('{delete_objects_values}');
-        delete from harvest_object where id in ('{delete_objects_values}');
-        delete from harvest_gather_error where harvest_job_id in ('{delete_jobs_values}');
-        delete from harvest_job where id in ('{delete_jobs_values}');
+        delete from harvest_object_error
+        where harvest_object_id in ('{delete_objects_values}');
+        delete from harvest_object_extra
+        where harvest_object_id in ('{delete_objects_values}');
+        delete from harvest_object
+        where id in ('{delete_objects_values}');
+        delete from harvest_gather_error
+        where harvest_job_id in ('{delete_jobs_values}');
+        delete from harvest_job
+        where id in ('{delete_jobs_values}');
         commit;
         '''.format(delete_objects_values="','".join(delete_objects_ids_all),
                    delete_jobs_values="','".join(delete_jobs_ids_all))
-        result = model.Session.execute(sql)
+        model.Session.execute(sql)
 
         # reindex after deletions
         tk.get_action('harvest_sources_reindex')(context, {})
 
     # return result of action
-    return {'cleared_sources': sources_to_clear,
+    return {'sources': sources_to_cleanup,
+            'deleted_jobs': delete_jobs_ids_all,
             'deleted_nr_jobs': len(delete_jobs_ids_all),
             'deleted_nr_objects': len(delete_objects_ids_all)}

--- a/ckanext/switzerland/plugin.py
+++ b/ckanext/switzerland/plugin.py
@@ -109,7 +109,7 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'ogdch_dataset_by_identifier': l.ogdch_dataset_by_identifier,
             'ogdch_content_headers': l.ogdch_content_headers,
             'ogdch_autosuggest': l.ogdch_autosuggest,
-            'ogdch_clean_harvester_jobs': l.ogdch_clean_harvester_jobs,
+            'ogdch_cleanup_harvestjobs': l.ogdch_cleanup_harvestjobs,
         }
 
     # ITemplateHelpers

--- a/ckanext/switzerland/plugin.py
+++ b/ckanext/switzerland/plugin.py
@@ -109,6 +109,7 @@ class OgdchPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'ogdch_dataset_by_identifier': l.ogdch_dataset_by_identifier,
             'ogdch_content_headers': l.ogdch_content_headers,
             'ogdch_autosuggest': l.ogdch_autosuggest,
+            'ogdch_clean_harvester_jobs': l.ogdch_clean_harvester_jobs,
         }
 
     # ITemplateHelpers


### PR DESCRIPTION
Command deletes all harvester jobs and objects for harvester source or for all sources
except the latest n, where n is determined by a ckan setting