### PR TITLE
Add groups to showcases and facet on them

### DIFF
--- a/ckanext/switzerland/helpers.py
+++ b/ckanext/switzerland/helpers.py
@@ -533,3 +533,30 @@ def showcase_types():
 def get_showcase_type_name(showcase_type):
     type_string = showcase_types_mapping.get(showcase_type, showcase_type)
     return get_localized_value(parse_json(type_string))
+
+
+def group_name_in_groups(group_name, groups):
+    for group in groups:
+        if group_name == group['name']:
+            return True
+    return False
+
+
+def get_localized_group_list():
+    """
+    Returns a list of dicts containing the id, name and localized title
+    for each group.
+    """
+    user = tk.get_action('get_site_user')({'ignore_auth': True}, {})
+    req_context = {'user': user['name']}
+    groups = tk.get_action('group_list')(req_context, {'all_fields': True})
+    group_list = []
+    for group in groups:
+        group_list.append({
+            'id': group['id'],
+            'name': group['name'],
+            'title': get_localized_value(group['title'], i18n.get_lang()),
+        })
+
+    group_list.sort(key=lambda group: strip_accents(group['title'].lower()), reverse=False)  # noqa
+    return group_list

--- a/ckanext/switzerland/plugin.py
+++ b/ckanext/switzerland/plugin.py
@@ -1,5 +1,6 @@
 # coding=UTF-8
 
+from ckan.common import OrderedDict
 from ckanext.showcase.plugin import ShowcasePlugin
 from ckanext.switzerland import validators as v
 from ckanext.switzerland import logic as l
@@ -727,7 +728,25 @@ class OgdchShowcasePlugin(ShowcasePlugin):
                 "showcase_type": [
                     toolkit.get_validator("ignore_missing"),
                     toolkit.get_converter("convert_to_extras"),
-                ]
+                ],
+                "groups": {
+                    "id": [
+                        toolkit.get_validator("ignore_missing"),
+                        toolkit.get_validator("unicode_safe"),
+                    ],
+                    "name": [
+                        toolkit.get_validator("ignore_missing"),
+                        toolkit.get_validator("unicode_safe"),
+                    ],
+                    "title": [
+                        toolkit.get_validator("ignore_missing"),
+                        toolkit.get_validator("unicode_safe"),
+                    ],
+                    "display_name": [
+                        toolkit.get_validator("ignore_missing"),
+                        toolkit.get_validator("unicode_safe"),
+                    ],
+                }
             }
         )
         return schema
@@ -749,7 +768,25 @@ class OgdchShowcasePlugin(ShowcasePlugin):
                 "showcase_type": [
                     toolkit.get_converter("convert_from_extras"),
                     toolkit.get_validator("ignore_missing"),
-                ]
+                ],
+                "groups": {
+                    "id": [
+                        toolkit.get_validator("ignore_missing"),
+                        toolkit.get_validator("unicode_safe"),
+                    ],
+                    "name": [
+                        toolkit.get_validator("ignore_missing"),
+                        toolkit.get_validator("unicode_safe"),
+                    ],
+                    "title": [
+                        toolkit.get_validator("ignore_missing"),
+                        toolkit.get_validator("unicode_safe"),
+                    ],
+                    "display_name": [
+                        toolkit.get_validator("ignore_missing"),
+                        toolkit.get_validator("unicode_safe"),
+                    ],
+                }
             }
         )
         return schema
@@ -760,6 +797,8 @@ class OgdchShowcasePlugin(ShowcasePlugin):
         helpers = super(OgdchShowcasePlugin, self).get_helpers()
         helpers["showcase_types"] = sh.showcase_types
         helpers["get_showcase_type_name"] = sh.get_showcase_type_name
+        helpers["get_localized_group_list"] = sh.get_localized_group_list
+        helpers["group_name_in_groups"] = sh.group_name_in_groups
 
         return helpers
 
@@ -769,13 +808,10 @@ class OgdchShowcasePlugin(ShowcasePlugin):
         if package_type != "showcase":
             return facets_dict
 
-        facets_dict = super(OgdchShowcasePlugin, self).dataset_facets(
-            facets_dict,
-            package_type
-        )
-        facets_dict["showcase_type"] = toolkit._("Type of content")
-
-        return facets_dict
+        return OrderedDict({
+            "groups": toolkit._("Categories"),
+            "showcase_type": toolkit._("Type of content")
+        })
 
 
 class LangToString(object):

--- a/ckanext/switzerland/templates/showcase/new_package_form.html
+++ b/ckanext/switzerland/templates/showcase/new_package_form.html
@@ -24,6 +24,23 @@
       {{ form.input('tag_string', id='field-tags', label=_('Tags'), placeholder=_('eg. economy, mental health, government'), value=data.tag_string, error=errors.tags, classes=['control-full'], attrs=tag_attrs) }}
     {% endblock %}
 
+    {% block dataset_fields %}
+      {% set groups = h.get_localized_group_list() %}
+      {% if groups %}
+        <div class="form-group control-medium">
+          <label class="control-label">{{ _('Categories') }}</label>
+          <div class="controls">
+            {% for group in groups %}
+              <label class="checkbox" for="field-group-{{ loop.index0 }}">
+                <input id="field-group-{{ loop.index0 }}" type="checkbox" name="groups__{{ loop.index0 }}__id" value="{{ group.id }}" {% if h.group_name_in_groups(group.name, data.get('groups', [])) %}checked{% endif %} />
+                {{ group.title }}
+              </label>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+    {% endblock %}
+
     {% block package_basic_fields_type %}
     <div class="form-group control-medium">
       <label class="control-label" for="field-showcase_type">{{ _("Type of content") }}</label>

--- a/ckanext/switzerland/templates/showcase/snippets/showcase_info.html
+++ b/ckanext/switzerland/templates/showcase/snippets/showcase_info.html
@@ -16,28 +16,6 @@ Example:
           {% block package_info_inner %}
           {% set type = pkg.get("showcase_type") %}
           <div class="row">
-            {% if pkg.author %}
-              <div class="col-md-3 col-sm-6">
-                <dl>
-                  <dt>{{ _('Submitted by') }}</dt>
-                  <dd>
-                    <p>{{ pkg.author }}</p>
-                  </dd>
-                </dl>
-              </div>
-            {% endif %}
-            {% if tags %}
-              <div class="col-md-3 col-sm-6">
-                <dl>
-                  <dt>{{ _('Tags') }}</dt>
-                  <dd>
-                    {% for tag in tags %}
-                      <a class="{% block tag_list_item_class %}tag{% endblock %}" href="{% url_for controller='ckanext.showcase.controller:ShowcaseController', action='search', tags=tag.name %}">{{ h.truncate(tag.display_name, 22) }}</a>{% if not loop.last %}, {% endif %}
-                    {% endfor %}
-                  </dd>
-                </dl>
-              </div>
-            {% endif %}
             {% if type %}
               <div class="col-md-3 col-sm-6">
                 <dl>
@@ -48,14 +26,55 @@ Example:
                 </dl>
               </div>
             {% endif %}
+            {% if pkg.get("groups") %}
+              {% set groups = pkg.get("groups") %}
+              <div class="col-md-3 col-sm-6">
+                <dl>
+                  <dt>{{ _('Categories') }}</dt>
+                  <dd>
+                    {% for group in groups %}
+                      <a class="{% block group_list_item_class %}group['name']{% endblock %}" href="{% url_for controller='ckanext.showcase.controller:ShowcaseController', action='search', groups=group['name'] %}">{{ h.truncate(group['title'], 22) }}</a>{% if not loop.last %}, {% endif %}
+                    {% endfor %}
+                  </dd>
+                </dl>
+              </div>
+            {% endif %}
+            {% if tags %}
+              <div class="col-md-3 col-sm-6">
+                <dl>
+                  <dt>{{ _('Tags') }}</dt>
+                  <dd>
+                    {% for tag in tags %}
+                    <a class="{% block tag_list_item_class %}tag{% endblock %}" href="{% url_for controller='ckanext.showcase.controller:ShowcaseController', action='search', tags=tag.name %}">{{ h.truncate(tag.display_name, 22) }}</a>{% if not loop.last %}, {% endif %}
+                    {% endfor %}
+                    </ul>
+                  </dd>
+                </dl>
+              </div>
+            {% endif %}
+            {% if pkg.author %}
+              <div class="col-md-3 col-sm-6">
+                <dl>
+                  <dt>{{ _('Submitted by') }}</dt>
+                  <dd>
+                    <p>{{ pkg.author }}</p>
+                  </dd>
+                </dl>
+              </div>
+            {% endif %}
+          </div>
+          <div class="row">
             {% if pkg.url %}
-            <div class="col-md-3 col-sm-6">
-              <a class="btn btn-primary" href="{{ pkg.url }}" target="_blank">
-                <i class="fa fa-external-link icon-external-link"></i> {{ _('Launch website') }}
-              </a>
-            </div>
+              <div class="col-md-3 col-sm-6">
+                <dl>
+                <a class="btn btn-primary" href="{{ pkg.url }}" target="_blank">
+                  <i class="fa fa-external-link icon-external-link"></i> {{ _('Launch website') }}
+                </a>
+                </dl>
+              </div>
             {% endif %}
           {% endblock %}
+          </div>
         </div>
         </div>
       </div>


### PR DESCRIPTION
This PR adds groups to the showcase schema, allowing admins to add any of the existing groups to a showcase (adding multiple groups is possible).

Groups are displayed on the showcase itself, and the list of showcases can be faceted by group. The faceting works the same way as with datasets, so a user can filter by both group and showcase type (added in #242).

Tags are now displayed on the individual showcase page but not exposed as a facet.